### PR TITLE
Adding instructions to README on how to run tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ This module shows how you can use Hypersistence Optimizer with Java EE and Glass
 
 This module shows how you can use Hypersistence Optimizer with Java EE, GlassFish, and Hibernate 4.
 
+## How to run tests?
+
+* Install JDK 8
+* Install and run MySQL server on localhost with following configuration:
+    * DatabaseName: high_performance_java_persistence
+    * Port: 3306
+    * UserName: mysql
+    * Password: admin
+ 
+    You can use **docker-compose** for running mysql server using the command: `hypersistence-optimizer> docker-compose up`
+* Run tests: `hypersistence-optimizer> mvn clean install`
+
 ## Issue management
 
 If you'd like to create a new issue, be it a feature request or simply reporting a bug, then you can use [this GitHub repository issue list](https://github.com/vladmihalcea/hypersistence-optimizer/issues).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.3'
+
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    ports:
+    - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: high_performance_java_persistence
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: admin


### PR DESCRIPTION
The tests are expected to run with Java 8 and having mysql installed, but is not obvious unless digging into the code. So adding the instructions to README. Also, as a convenience adding `docker-compose.yml` file to easily spin up MySQL docker container.